### PR TITLE
Add template metaflow flows!

### DIFF
--- a/src/mozmlops/templates/example_config.json
+++ b/src/mozmlops/templates/example_config.json
@@ -1,0 +1,3 @@
+{
+  "example_key" : "Hello world!"
+}

--- a/src/mozmlops/templates/template_flow.py
+++ b/src/mozmlops/templates/template_flow.py
@@ -1,0 +1,111 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import os
+
+from metaflow import (
+    FlowSpec, IncludeFile, Parameter,
+    card, current, step,
+    environment, kubernetes
+)
+from metaflow.cards import Markdown
+
+from artifact_store import ArtifactStore
+
+GCS_PROJECT_NAME = "project-name-here"
+GCS_BUCKET_NAME = "bucket-name-here"
+
+class TemplateFlow(FlowSpec):
+    """
+    This flow is a template for you to use
+    for orchestration of your model.
+    """
+
+    # You can import the contents of files from your file system to use in flows.
+    # This is meant for small files—in this example, a bit of config.
+    example_config = IncludeFile("example_config", default="./example_config.json")
+
+    # This is an example of a parameter. You can toggle this when you call the flow
+    # with python template_flow.py run --offline False
+    offline_wandb = Parameter(
+        "offline",
+        help="Do not connect to W&B servers when training",
+        type=bool,
+        default=True
+    )
+
+    # You can uncomment and adjust this decorator when it's time to scale your flow remotely.
+    # @kubernetes(image="url-to-docker-image:tag", cpu=1)
+    @card(type="default")
+    @step
+    def start(self):
+        """
+        Each flow has a 'start' step.
+
+        You can use it for collecting/preprocessing data or other setup tasks.
+        """
+
+        self.next(self.train)
+
+    @card
+    @environment(vars={
+        "WANDB_API_KEY": os.getenv("WANDB_API_KEY"),
+        "WANDB_ENTITY": os.getenv("WANDB_ENTITY"),
+        "WANDB_PROJECT": os.getenv("WANDB_PROJECT")
+    })
+    # Note: the image parameter must be a fully qualified registry path otherwise Metaflow will default to
+    # the AWS public registry.
+    # You can uncomment and adjust this decorator when it's time to scale your flow remotely.
+    # @kubernetes(image="url-to-docker-image:tag", gpu=0)
+    @step
+    def train(self):
+        """
+        In this step you can train your model,
+        save checkpoints and artifacts,
+        and deliver data to Weights and Biases
+        for experiment evaluation
+        """
+        import json
+        import wandb
+
+        # This can help you fetch and upload artifacts to
+        # GCS. Check out help(ArtifactStore) for more details.
+        artifact_store = ArtifactStore(
+            project_name=GCS_PROJECT_NAME, bucket_name=GCS_BUCKET_NAME
+        )
+
+        config_as_dict = json.loads(self.example_config)
+        print(f"The config file says: {config_as_dict.get('example_key')}")
+
+        if not self.offline_wandb:
+            tracking_run = wandb.init(
+                project=os.getenv("WANDB_PROJECT")
+            )
+            wandb_url = tracking_run.get_url()
+            current.card.append(Markdown(f"# Weights & Biases"))
+            current.card.append(Markdown(f"Your training run is tracked [here]({wandb_url})."))
+
+        print(f"All set. Running training.")
+        # Model training goes here
+
+        self.next(self.end)
+
+    @step
+    def end(self):
+        """
+        This is the mandatory 'end' step: it prints some helpful information
+        to access the model and the used dataset.
+        """
+        print(
+            f"""
+            Flow complete.
+
+            See artifacts at {GCS_BUCKET_NAME}.
+            """
+        )
+
+
+if __name__ == "__main__":
+    TemplateFlow()
+

--- a/src/mozmlops/templates/template_flow.py
+++ b/src/mozmlops/templates/template_flow.py
@@ -11,7 +11,7 @@ from metaflow import (
 )
 from metaflow.cards import Markdown
 
-from artifact_store import ArtifactStore
+from mozmlops.artifact_store import ArtifactStore
 
 GCS_PROJECT_NAME = "project-name-here"
 GCS_BUCKET_NAME = "bucket-name-here"


### PR DESCRIPTION
### Goal(s) of this Pull Request:

- We want to make it easy for our clients (Machine Learning Engineers on subject matter teams at Mozilla) to quickly productionize their models using the tools we've (painstakingly) prepared for them. This example flow provides them a starting point with:

1. An existing `FlowSpec` for using the Metaflow API for model orchestration
2. Existing integration with Weights & Biases for experiment analysis
3. Examples of the pieces many MLE teams will need, like including config files, running on docker containers, and logging events.

### Example of how it works:

Out of the box, the flow should "work"—that is, doing `python template_flow.py show` should give an outline of the steps and their descriptions, and `python template_flow.py run` should run the flow on our production outerbounds instance (provided that the client is set up to use Outerbounds—README for that in the next PR).

### Acceptance criteria:

In order to approve, reviewer must be able to...

- [ ] `cd` into the folder with `template_flow.py`, run `python template_flow.py show`, and get an outline of the steps
- [ ] `cd` into the folder with `template_flow.py` (having already been set up with the Mozilla Outerbounds instance), run `python template_flow.py run`, and have the flow run on our production Outerbounds instance.