### PR TITLE
Commit results of running  format

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,9 +6,9 @@
 
 # -- Project information -----------------------------------------------------
 
-project = u"mozmlops"
-copyright = u"2024, Mozilla MLOps"
-author = u"Mozilla MLOps"
+project = "mozmlops"
+copyright = "2024, Mozilla MLOps"
+author = "Mozilla MLOps"
 
 # -- General configuration ---------------------------------------------------
 

--- a/src/mozmlops/__init__.py
+++ b/src/mozmlops/__init__.py
@@ -1,3 +1,4 @@
 # read version from installed package
 from importlib.metadata import version
+
 __version__ = version("mozmlops")

--- a/src/mozmlops/cloud_storage_api_client.py
+++ b/src/mozmlops/cloud_storage_api_client.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
+
 class CloudStorageAPIClient:
     """
     This module provides functions for interacting with Google Cloud Storage.
@@ -20,19 +21,20 @@ class CloudStorageAPIClient:
 
     to which that instance will upload, and from which that instance will fetch.
     """
+
     def __init__(self, project_name: str, bucket_name: str):
         self.gcs_project_name = project_name
         self.gcs_bucket_name = bucket_name
-    
+
     def store(self, data: bytes, storage_path: str) -> str:
         """
         Arguments:
         data (bytes): The data to be stored in the cloud.
         storage_path (str): The filepath where the data will be stored.
 
-        Places a blob of data, represented in bytes, 
+        Places a blob of data, represented in bytes,
         at a specific filepath within the GCS project and bucket specified
-        when the CloudStorageAPIClient was initialized. 
+        when the CloudStorageAPIClient was initialized.
         """
         from google.cloud import storage
         from google.cloud.exceptions import GoogleCloudError
@@ -56,7 +58,9 @@ class CloudStorageAPIClient:
                 logging.info(log_line)
             except GoogleCloudError as e:
                 if e.code == 412:
-                    raise Exception("The object you tried to upload is already in the GCS bucket. Currently, the .store() function's implementation dictates this behavior.").with_traceback(e.__traceback__)
+                    raise Exception(
+                        "The object you tried to upload is already in the GCS bucket. Currently, the .store() function's implementation dictates this behavior."
+                    ).with_traceback(e.__traceback__)
                 raise e
 
         return storage_path
@@ -67,9 +71,9 @@ class CloudStorageAPIClient:
         remote_path (str): The filepath on GCS from which to fetch the data.
         storage_path (str): The local filepath in which to store the data.
 
-        Fetches a file 
+        Fetches a file
         at a specific remote_path within the GCS project and bucket specified
-        and stores it at a location specified by local_path. 
+        and stores it at a location specified by local_path.
         """
         from google.cloud import storage
 
@@ -102,4 +106,3 @@ class CloudStorageAPIClient:
         blob = bucket.blob(remote_path)
 
         blob.delete()
-

--- a/src/mozmlops/templates/template_flow.py
+++ b/src/mozmlops/templates/template_flow.py
@@ -5,9 +5,14 @@
 import os
 
 from metaflow import (
-    FlowSpec, IncludeFile, Parameter,
-    card, current, step,
-    environment, kubernetes # noqa: F401
+    FlowSpec,
+    IncludeFile,
+    Parameter,
+    card,
+    current,
+    step,
+    environment,
+    kubernetes,  # noqa: F401
 )
 from metaflow.cards import Markdown
 
@@ -16,6 +21,7 @@ from mozmlops.cloud_storage_api_client import CloudStorageAPIClient
 
 GCS_PROJECT_NAME = "project-name-here"
 GCS_BUCKET_NAME = "bucket-name-here"
+
 
 class TemplateFlow(FlowSpec):
     """
@@ -33,7 +39,7 @@ class TemplateFlow(FlowSpec):
         "offline",
         help="Do not connect to W&B servers when training",
         type=bool,
-        default=True
+        default=True,
     )
 
     # You can uncomment and adjust this decorator when it's time to scale your flow remotely.
@@ -50,11 +56,13 @@ class TemplateFlow(FlowSpec):
         self.next(self.train)
 
     @card
-    @environment(vars={
-        "WANDB_API_KEY": os.getenv("WANDB_API_KEY"),
-        "WANDB_ENTITY": os.getenv("WANDB_ENTITY"),
-        "WANDB_PROJECT": os.getenv("WANDB_PROJECT")
-    })
+    @environment(
+        vars={
+            "WANDB_API_KEY": os.getenv("WANDB_API_KEY"),
+            "WANDB_ENTITY": os.getenv("WANDB_ENTITY"),
+            "WANDB_PROJECT": os.getenv("WANDB_PROJECT"),
+        }
+    )
     # Note: the image parameter must be a fully qualified registry path otherwise Metaflow will default to
     # the AWS public registry.
     # You can uncomment and adjust this decorator when it's time to scale your flow remotely.
@@ -80,25 +88,27 @@ class TemplateFlow(FlowSpec):
         print(f"The config file says: {config_as_dict.get('example_key')}")
 
         if not self.offline_wandb:
-            tracking_run = wandb.init(
-                project=os.getenv("WANDB_PROJECT")
-            )
+            tracking_run = wandb.init(project=os.getenv("WANDB_PROJECT"))
             wandb_url = tracking_run.get_url()
             current.card.append(Markdown("# Weights & Biases"))
-            current.card.append(Markdown(f"Your training run is tracked [here]({wandb_url})."))
+            current.card.append(
+                Markdown(f"Your training run is tracked [here]({wandb_url}).")
+            )
 
         print("All set. Running training.")
         # Model training goes here
 
-        remote_path = os.path.join(current.flow_name, current.run_id, "example_filename.txt")
-        
+        remote_path = os.path.join(
+            current.flow_name, current.run_id, "example_filename.txt"
+        )
+
         # Example: How you'd store a checkpoint in the cloud
         example_blob = bytearray([1, 2, 3, 4, 5])
         storage_client.store(data=example_blob, storage_path=remote_path)
 
         # Example: How you'd fetch a checkpoint from the cloud
         storage_client.fetch(remote_path=remote_path, local_path="example_filename.txt")
-        
+
         self.next(self.end)
 
     @step
@@ -118,4 +128,3 @@ class TemplateFlow(FlowSpec):
 
 if __name__ == "__main__":
     TemplateFlow()
-

--- a/tests/integration/test_cloud_storage_api_client.py
+++ b/tests/integration/test_cloud_storage_api_client.py
@@ -4,60 +4,76 @@ from mozmlops.cloud_storage_api_client import CloudStorageAPIClient
 
 import pytest
 
+
 @pytest.mark.integration
 def test_store_fetch_delete__nominal(tmp_path):
     """
-    Test the integration to store a file, fetch a file, and delete a file. 
+    Test the integration to store a file, fetch a file, and delete a file.
     This test takes several seconds to run.
 
-    If this test fails, one of the integrations is broken. 
+    If this test fails, one of the integrations is broken.
     Each has its own assertions and error messages, designed to help pinpoint the failure.
     You can also visit the bucket on GCS to find the file:
 
     https://console.cloud.google.com/storage/browser/mozdata-tmp
 
-    These functions are tested together as a top-level integration test because: 
-    
+    These functions are tested together as a top-level integration test because:
+
     1. .store() and .fetch() are inverse operations, and then .delete() cleans up after .store()
     2. Testing these functions separately requires independently recreating the integrations,
     3. Which duplicates the logic while failing to actually isolate the integration behaviors.
     """
     # Given an artifact store and a file containing Ada Lovelace's name:
 
-    storage_client = CloudStorageAPIClient(project_name="mozdata", bucket_name="mozdata-tmp")
+    storage_client = CloudStorageAPIClient(
+        project_name="mozdata", bucket_name="mozdata-tmp"
+    )
 
     string_to_store = "Ada Lovelace"
     timestamp = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
     filename_to_store_it_at = f"first_computer_programmer_{timestamp}.txt"
-    encoded_string = string_to_store.encode(encoding='utf-8')
+    encoded_string = string_to_store.encode(encoding="utf-8")
 
-    # When we use .store() to call for her name to be stored on GCS, the command succeeds: 
+    # When we use .store() to call for her name to be stored on GCS, the command succeeds:
 
-    filepath = storage_client.store(data=encoded_string, storage_path=filename_to_store_it_at)
+    filepath = storage_client.store(
+        data=encoded_string, storage_path=filename_to_store_it_at
+    )
     assert filepath == filename_to_store_it_at, "The model was not stored as we expect."
 
     # And when we use .fetch() to call for the file to be fetched from GCS, we can retrieve her name:
 
     try:
-        storage_client.fetch(remote_path=filename_to_store_it_at, local_path=f"{tmp_path}/{filename_to_store_it_at}")
+        storage_client.fetch(
+            remote_path=filename_to_store_it_at,
+            local_path=f"{tmp_path}/{filename_to_store_it_at}",
+        )
 
         with open(f"{tmp_path}/{filename_to_store_it_at}", "rb") as file:
             encoded_stored_string = file.read()
-            decoded_stored_string = encoded_stored_string.decode(encoding='utf-8')
-            assert decoded_stored_string == string_to_store, "The model was not fetched as we expect."
+            decoded_stored_string = encoded_stored_string.decode(encoding="utf-8")
+            assert (
+                decoded_stored_string == string_to_store
+            ), "The model was not fetched as we expect."
 
-    # And when we use .delete() to call for the file to be deleted, provided it's possible that our file _uploaded_, we can delete it: 
+    # And when we use .delete() to call for the file to be deleted, provided it's possible that our file _uploaded_, we can delete it:
     # (Lives in a finally block so the file is cleaned up even if fetching fails)
-    finally: 
+    finally:
         storage_client._CloudStorageAPIClient__delete(filename_to_store_it_at)
 
         try:
             # This line assumes fetch is working (which we believe we're testing for above)
-            storage_client.fetch(remote_path=filename_to_store_it_at, local_path=f"{tmp_path}/{filename_to_store_it_at}")
-            
-            pytest.fail("The model was not deleted as we expect; it's still on the GCS file system.")
+            storage_client.fetch(
+                remote_path=filename_to_store_it_at,
+                local_path=f"{tmp_path}/{filename_to_store_it_at}",
+            )
+
+            pytest.fail(
+                "The model was not deleted as we expect; it's still on the GCS file system."
+            )
         except Exception as e:
             assert "No such object" in e.message
+
 
 @pytest.mark.integration
 def test_store__existing_filename__throws_clear_exception():
@@ -68,16 +84,20 @@ def test_store__existing_filename__throws_clear_exception():
     """
     # Given an artifact store and a file containing Grace Hopper's name:
 
-    storage_client = CloudStorageAPIClient(project_name="mozdata", bucket_name="mozdata-tmp")
+    storage_client = CloudStorageAPIClient(
+        project_name="mozdata", bucket_name="mozdata-tmp"
+    )
 
     string_to_store = "Grace Hopper"
     timestamp = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
     filename_to_store_it_at = f"coined_the_term_bug_{timestamp}.txt"
-    encoded_string = string_to_store.encode(encoding='utf-8')
+    encoded_string = string_to_store.encode(encoding="utf-8")
 
-    # After we call .store() for that object and location once: 
+    # After we call .store() for that object and location once:
 
-    returned_storage_path = storage_client.store(data=encoded_string, storage_path=filename_to_store_it_at)
+    returned_storage_path = storage_client.store(
+        data=encoded_string, storage_path=filename_to_store_it_at
+    )
     assert returned_storage_path == filename_to_store_it_at
 
     # When we do it again:

--- a/tests/unit/test_example.py
+++ b/tests/unit/test_example.py
@@ -3,4 +3,4 @@ def test_example():
     Example test for kicking off the unit test suite.
     Used to check that pytest --ignore=tests/integration works as expected.
     """
-    assert 1==1
+    assert 1 == 1


### PR DESCRIPTION
### Goal(s) of this Pull Request:

- Get our Python file formatting on the same page as the ruff formatter

### Example of how it works:

You can run `ruff format` and confirm that there are now no formatting errors, but this PR does not change any code behavior. 

### Acceptance criteria:

In order to approve, reviewer must be able to...

- [x] Run `ruff format` and see no formatting errors
- [x] Run `pytest` and `pytest -m integration` and see that all tests still pass