### PR TITLE
Ctroy dockerize

### DIFF
--- a/src/mozmlops/templates/.dockerignore
+++ b/src/mozmlops/templates/.dockerignore
@@ -1,0 +1,34 @@
+# Include any files or directories that you don't want to be copied to your
+# container here (e.g., local build artifacts, temporary files, etc.).
+#
+# For more help, visit the .dockerignore file reference guide at
+# https://docs.docker.com/go/build-context-dockerignore/
+
+**/.DS_Store
+**/__pycache__
+**/.venv
+**/.classpath
+**/.dockerignore
+**/.env
+**/.git
+**/.gitignore
+**/.project
+**/.settings
+**/.toolstarget
+**/.vs
+**/.vscode
+**/*.*proj.user
+**/*.dbmdl
+**/*.jfm
+**/bin
+**/charts
+**/docker-compose*
+**/compose*
+**/Dockerfile*
+**/node_modules
+**/npm-debug.log
+**/obj
+**/secrets.dev.yaml
+**/values.dev.yaml
+LICENSE
+README.md

--- a/src/mozmlops/templates/Dockerfile
+++ b/src/mozmlops/templates/Dockerfile
@@ -4,8 +4,7 @@
 # If you need more help, visit the Dockerfile reference guide at
 # https://docs.docker.com/go/dockerfile-reference/
 
-ARG TAG=3.10.11-bullseye
-FROM --platform=linux/amd64 python:${TAG} as base
+FROM --platform=linux/amd64 python:3.10.11-bullseye
 
 # Prevents Python from writing pyc files.
 ENV PYTHONDONTWRITEBYTECODE=1

--- a/src/mozmlops/templates/Dockerfile
+++ b/src/mozmlops/templates/Dockerfile
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1
+
+# Comments are provided throughout this file to help you get started.
+# If you need more help, visit the Dockerfile reference guide at
+# https://docs.docker.com/go/dockerfile-reference/
+
+ARG TAG=3.10.11-bullseye
+FROM python:${TAG} as base
+
+# Prevents Python from writing pyc files.
+ENV PYTHONDONTWRITEBYTECODE=1
+
+# Keeps Python from buffering stdout and stderr to avoid situations where
+# the application crashes without emitting any logs due to buffering.
+ENV PYTHONUNBUFFERED=1
+
+COPY requirements.txt requirements.txt
+
+RUN python -m pip install -r requirements.txt 

--- a/src/mozmlops/templates/Dockerfile
+++ b/src/mozmlops/templates/Dockerfile
@@ -5,7 +5,7 @@
 # https://docs.docker.com/go/dockerfile-reference/
 
 ARG TAG=3.10.11-bullseye
-FROM python:${TAG} as base
+FROM --platform=linux/amd64 python:${TAG} as base
 
 # Prevents Python from writing pyc files.
 ENV PYTHONDONTWRITEBYTECODE=1

--- a/src/mozmlops/templates/Dockerfile
+++ b/src/mozmlops/templates/Dockerfile
@@ -6,13 +6,10 @@
 
 FROM --platform=linux/amd64 python:3.10.11-bullseye
 
-# Prevents Python from writing pyc files.
-ENV PYTHONDONTWRITEBYTECODE=1
-
 # Keeps Python from buffering stdout and stderr to avoid situations where
 # the application crashes without emitting any logs due to buffering.
 ENV PYTHONUNBUFFERED=1
 
-COPY requirements.txt requirements.txt
+COPY requirements.outerbounds.txt requirements.outerbounds.txt
 
 RUN python -m pip install -r requirements.txt 

--- a/src/mozmlops/templates/README.Docker.md
+++ b/src/mozmlops/templates/README.Docker.md
@@ -1,0 +1,22 @@
+### Building and running your application
+
+When you're ready, start your application by running:
+`docker compose up --build`.
+
+Your application will be available at http://localhost:8000.
+
+### Deploying your application to the cloud
+
+First, build your image, e.g.: `docker build -t myapp .`.
+If your cloud uses a different CPU architecture than your development
+machine (e.g., you are on a Mac M1 and your cloud provider is amd64),
+you'll want to build the image for that platform, e.g.:
+`docker build --platform=linux/amd64 -t myapp .`.
+
+Then, push it to your registry, e.g. `docker push myregistry.com/myapp`.
+
+Consult Docker's [getting started](https://docs.docker.com/go/get-started-sharing/)
+docs for more detail on building and pushing.
+
+### References
+* [Docker's Python guide](https://docs.docker.com/language/python/)

--- a/src/mozmlops/templates/README.Docker.md
+++ b/src/mozmlops/templates/README.Docker.md
@@ -20,3 +20,25 @@ docs for more detail on building and pushing.
 
 ### References
 * [Docker's Python guide](https://docs.docker.com/language/python/)
+
+## _(Optional)_ Build and push a new Docker image
+The Docker image used in the training flow is derived from a python image
+and comes with a few additional dependencies required for training. 
+
+The template flow specifies the docker image with the @kubernetes decorator, 
+which needs a URL to get the docker image from.
+
+In order to make an updated image available at a URL, you'll need to push it somewhere. The easiest is [Dockerhub](https://hub.docker.com/). You'll need to create an account. It's free; the process is not unlike signing up for a Github account.
+
+Then, change and update the image as follows:
+
+1. Tweak the [`Dockerfile`](Dockerfile) as needed.
+2. Build the image: `docker build -t mlops-copilot-demo:<TAG> .` where `<TAG>` is an identifier
+used to version the image, for example `v3`.
+3. Run `docker images` to find the built image and its id.
+4. Tag the image with your DockerHub info: `docker tag <Image ID> <DockerHub user>/mozmlops:<TAG>`
+  where `<Image ID>` is the id from step 3, `<DockerHub user>` is
+  the Docker username and `<TAG>` is the version tag.
+5. Run `docker images` again to check that the new tag shows up.
+6. Push to Docker hub using `docker push <DockerHub user>/mlops-copilot-demo:<TAG>`.
+7. Update the reference image in the `@kubernetes` decorator in [`template_flow.py`](template_flow.py).

--- a/src/mozmlops/templates/compose.yaml
+++ b/src/mozmlops/templates/compose.yaml
@@ -1,0 +1,49 @@
+# Comments are provided throughout this file to help you get started.
+# If you need more help, visit the Docker Compose reference guide at
+# https://docs.docker.com/go/compose-spec-reference/
+
+# Here the instructions define your application as a service called "server".
+# This service is built from the Dockerfile in the current directory.
+# You can add other services your application may depend on here, such as a
+# database or a cache. For examples, see the Awesome Compose repository:
+# https://github.com/docker/awesome-compose
+services:
+  server:
+    build:
+      context: .
+    ports:
+      - 8000:8000
+
+# The commented out section below is an example of how to define a PostgreSQL
+# database that your application can use. `depends_on` tells Docker Compose to
+# start the database before your application. The `db-data` volume persists the
+# database data between container restarts. The `db-password` secret is used
+# to set the database password. You must create `db/password.txt` and add
+# a password of your choosing to it before running `docker compose up`.
+#     depends_on:
+#       db:
+#         condition: service_healthy
+#   db:
+#     image: postgres
+#     restart: always
+#     user: postgres
+#     secrets:
+#       - db-password
+#     volumes:
+#       - db-data:/var/lib/postgresql/data
+#     environment:
+#       - POSTGRES_DB=example
+#       - POSTGRES_PASSWORD_FILE=/run/secrets/db-password
+#     expose:
+#       - 5432
+#     healthcheck:
+#       test: [ "CMD", "pg_isready" ]
+#       interval: 10s
+#       timeout: 5s
+#       retries: 5
+# volumes:
+#   db-data:
+# secrets:
+#   db-password:
+#     file: db/password.txt
+

--- a/src/mozmlops/templates/requirements.outerbounds.txt
+++ b/src/mozmlops/templates/requirements.outerbounds.txt
@@ -1,0 +1,2 @@
+mozmlops==0.1.4
+scikit-learn==1.5.0 # Needed only for the example model in this template flow

--- a/src/mozmlops/templates/requirements.txt
+++ b/src/mozmlops/templates/requirements.txt
@@ -1,2 +1,0 @@
-mozmlops==0.1.4
-scikit-learn==1.5.0

--- a/src/mozmlops/templates/requirements.txt
+++ b/src/mozmlops/templates/requirements.txt
@@ -1,0 +1,2 @@
+mozmlops==0.1.4
+scikit-learn==1.5.0

--- a/src/mozmlops/templates/template_flow.py
+++ b/src/mozmlops/templates/template_flow.py
@@ -12,7 +12,8 @@ from metaflow import (
     current,
     step,
     environment,
-    kubernetes,  
+    kubernetes,  # noqa: F401
+    pypi,
 )
 from metaflow.cards import Markdown
 
@@ -60,14 +61,18 @@ class TemplateFlow(FlowSpec):
             "WANDB_PROJECT": os.getenv("WANDB_PROJECT"),
         }
     )
-
+    # This PyPI decorator allows you to specify dependencies for running flows remotely.
+    # If your dependency tree is more complicated than importing a few things from pip,
+    # You can also make a custom docker image and use that with the @kubernetes decorator
+    # as show in the comments a few lines down.
+    @pypi(
+        python="3.10.11",
+        packages={"scikit-learn": "1.5.0", "mozmlops": "0.1.4"},
+    )
     # You can uncomment and adjust this decorator to scale your flow remotely with a custom image.
     # Note: the image parameter must be a fully qualified registry path otherwise Metaflow will default to
     # the AWS public registry.
-    # The image referenced HERE is the mozmlops demo image, 
-    # which has both the dependencies you need run this template flow:
-    # scikit-learn (for the specific model called in this demo) and mozmlops (for all your ops tools).
-    @kubernetes(image="registry.hub.docker.com/chelseatroy/mozmlops:latest", cpu=1)
+    # @kubernetes(image="url-to-docker-image:tag", gpu=0)
     @step
     def train(self):
         """
@@ -78,9 +83,9 @@ class TemplateFlow(FlowSpec):
         """
         import json
         import wandb
-        from sklearn.datasets import load_iris  # noqa # pylint: disable=import-error
-        from sklearn.model_selection import train_test_split  # noqa # pylint: disable=import-error
-        from sklearn.linear_model import LogisticRegression  # noqa # pylint: disable=import-error
+        from sklearn.datasets import load_iris
+        from sklearn.model_selection import train_test_split
+        from sklearn.linear_model import LogisticRegression
         from mozmlops.cloud_storage_api_client import CloudStorageAPIClient  # noqa: F401
 
         # This can help you fetch and upload artifacts to

--- a/src/mozmlops/templates/template_flow.py
+++ b/src/mozmlops/templates/template_flow.py
@@ -12,7 +12,7 @@ from metaflow import (
     current,
     step,
     environment,
-    kubernetes,  
+    kubernetes,
 )
 from metaflow.cards import Markdown
 
@@ -60,11 +60,10 @@ class TemplateFlow(FlowSpec):
             "WANDB_PROJECT": os.getenv("WANDB_PROJECT"),
         }
     )
-
     # You can uncomment and adjust this decorator to scale your flow remotely with a custom image.
     # Note: the image parameter must be a fully qualified registry path otherwise Metaflow will default to
     # the AWS public registry.
-    # The image referenced HERE is the mozmlops demo image, 
+    # The image referenced HERE is the mozmlops demo image,
     # which has both the dependencies you need run this template flow:
     # scikit-learn (for the specific model called in this demo) and mozmlops (for all your ops tools).
     @kubernetes(image="registry.hub.docker.com/chelseatroy/mozmlops:latest", cpu=1)

--- a/src/mozmlops/templates/template_flow.py
+++ b/src/mozmlops/templates/template_flow.py
@@ -12,8 +12,7 @@ from metaflow import (
     current,
     step,
     environment,
-    kubernetes,  # noqa: F401
-    pypi,
+    kubernetes,  
 )
 from metaflow.cards import Markdown
 
@@ -61,18 +60,14 @@ class TemplateFlow(FlowSpec):
             "WANDB_PROJECT": os.getenv("WANDB_PROJECT"),
         }
     )
-    # This PyPI decorator allows you to specify dependencies for running flows remotely.
-    # If your dependency tree is more complicated than importing a few things from pip,
-    # You can also make a custom docker image and use that with the @kubernetes decorator
-    # as show in the comments a few lines down.
-    @pypi(
-        python="3.10.11",
-        packages={"scikit-learn": "1.5.0", "mozmlops": "0.1.4"},
-    )
+
     # You can uncomment and adjust this decorator to scale your flow remotely with a custom image.
     # Note: the image parameter must be a fully qualified registry path otherwise Metaflow will default to
     # the AWS public registry.
-    # @kubernetes(image="url-to-docker-image:tag", gpu=0)
+    # The image referenced HERE is the mozmlops demo image, 
+    # which has both the dependencies you need run this template flow:
+    # scikit-learn (for the specific model called in this demo) and mozmlops (for all your ops tools).
+    @kubernetes(image="registry.hub.docker.com/chelseatroy/mozmlops:latest", cpu=1)
     @step
     def train(self):
         """
@@ -83,9 +78,9 @@ class TemplateFlow(FlowSpec):
         """
         import json
         import wandb
-        from sklearn.datasets import load_iris
-        from sklearn.model_selection import train_test_split
-        from sklearn.linear_model import LogisticRegression
+        from sklearn.datasets import load_iris  # noqa # pylint: disable=import-error
+        from sklearn.model_selection import train_test_split  # noqa # pylint: disable=import-error
+        from sklearn.linear_model import LogisticRegression  # noqa # pylint: disable=import-error
         from mozmlops.cloud_storage_api_client import CloudStorageAPIClient  # noqa: F401
 
         # This can help you fetch and upload artifacts to


### PR DESCRIPTION
### Goal(s) of this Pull Request:

- Use the `kubernetes` decorator: it can serve our most complex case for model orchestration deployment and isn't especially costly for the simplest one, so we want to default to it for all builds. 
- Get a prebuilt docker image working with aforementioned decorator
- Include documentation about how to update that docker image

### Example of how it works:

- see README.docker.md for instructions for upkeep
- See Dockerfile for building details
- See template_flow.py for where that image gets pulled down (it's pushed to dockerhub).

### Open questions:

**1. tagging**: so far I've tagged 'latest.' Now, ideally, no one is trying to use this image ever except the mozmlops template, in which case this would not be an issue. We could, however, switch to semantic versioning.

**2. including the machine architecture in the tag**: like, naming the tag linux-amd-64-0.0.1 so it's clear that this build is for a specific architecture, lest anybody try to hoyk it down and run it locally on a mac. Now, again, the thing should only get pulled by the template flow if that flow is run --with kubernetes, so we don't have a current need for this system, but it might make sense if some unforeseen event results in a need to have prebuilt images for different architectures. 

