### PR TITLE
Add Dockerfile inline documentation and README 

### DIFF
--- a/src/mozmlops/templates/Dockerfile
+++ b/src/mozmlops/templates/Dockerfile
@@ -4,12 +4,17 @@
 # If you need more help, visit the Dockerfile reference guide at
 # https://docs.docker.com/go/dockerfile-reference/
 
+# This line specifies your base image.
+# For outerbounds, you should specify the platform as shown, even though that is not recommended online,
+# or else flows run into issues (especially when images are built on Macs and then run on Outerbounds's remote node pool machines).
 FROM --platform=linux/amd64 python:3.10.11-bullseye
 
 # Keeps Python from buffering stdout and stderr to avoid situations where
 # the application crashes without emitting any logs due to buffering.
 ENV PYTHONUNBUFFERED=1
 
+# Puts the dependencies from these two requirements lists into the Docker environment for installation
 COPY requirements.outerbounds.txt requirements.outerbounds.txt
 
+# Installs aforementioned dependencies
 RUN python -m pip install -r requirements.txt 

--- a/src/mozmlops/templates/Dockerfile-metaflow
+++ b/src/mozmlops/templates/Dockerfile-metaflow
@@ -13,8 +13,8 @@ FROM --platform=linux/amd64 python:3.10.11-bullseye
 # the application crashes without emitting any logs due to buffering.
 ENV PYTHONUNBUFFERED=1
 
-# Puts the dependencies from these two requirements lists into the Docker environment for installation
+# Puts the dependencies from this requirement list into the Docker environment for installation
 COPY requirements.outerbounds.txt requirements.outerbounds.txt
 
 # Installs aforementioned dependencies
-RUN python -m pip install -r requirements.txt 
+RUN python -m pip install -r requirements.outerbounds.txt

--- a/src/mozmlops/templates/README.Docker.md
+++ b/src/mozmlops/templates/README.Docker.md
@@ -32,7 +32,7 @@ In order to make an updated image available at a URL, you'll need to push it som
 
 Then, change and update the image as follows:
 
-1. Tweak the [`Dockerfile`](Dockerfile) as needed.
+1. Tweak the [`Dockerfile`](Dockerfile-metaflow) as needed.
 2. Build the image: `docker build -t mlops-copilot-demo:<TAG> .` where `<TAG>` is an identifier
 used to version the image, for example `v3`.
 3. Run `docker images` to find the built image and its id.

--- a/src/mozmlops/templates/README.md
+++ b/src/mozmlops/templates/README.md
@@ -155,7 +155,7 @@ As the Serve config file contents and the Dockerfile created in the previous ste
 
 1. Build the docker image locally using [docker build](https://docs.docker.com/reference/cli/docker/buildx/build/) command:
     ```sh
-    docker build -t template_rayserve_image:v1 -f Dockerfile-metaflow-rayserve .
+    docker build -t template_rayserve_image:v1 -f Dockerfile-rayserve .
     ```
 2. Run a container from the image using [docker run](https://docs.docker.com/reference/cli/docker/container/run/) command and start the Ray Serve app locally by running the [serve run](https://docs.ray.io/en/latest/serve/api/index.html#serve-run) command inside the container
 

--- a/src/mozmlops/templates/README.md
+++ b/src/mozmlops/templates/README.md
@@ -64,7 +64,7 @@ If you'd like to use a docker image, you can create your own custom image, push 
 ```commandLine
 @kubernetes(image='url/of/your/image:tag')
 ```
-You can see an example Dockerfile [here](`Dockerfile-metaflow`) in this templates directory.
+You can see an example Dockerfile [here](Dockerfile-metaflow) in this templates directory.
 
 Please note that if your step should use our NVIDIA GPUs, it cannot use a docker image at present, as the Outerbounds `@nvidia` decorator does not interoperate with docker image specification. In this case, please use the `@pypi` and `@conda` decorators for dependencies as documented above.
 

--- a/src/mozmlops/templates/README.md
+++ b/src/mozmlops/templates/README.md
@@ -58,13 +58,13 @@ Flows in Metaflow permit you to include dependencies in each of your steps in tw
 
 1. Adding the `@pypi` or `@conda` decorator and installing dependencies as each step runs ([documentation here](https://docs.metaflow.org/scaling/dependencies/libraries))
 2. Using a custom docker image with your dependencies in it, as described in [this documentation](https://docs.metaflow.org/scaling/dependencies/containers)
-   3. An important note: the above linked documentation says you can use docker images and the pypi and conda decorators together. According to the maintainers of the Outerbounds product that we use at Mozilla, this does not function as documented; instead, both the pypi and conda decorators start from a fresh environment. So if you specify _both_, the flow will _run_, but it will _fail_ if you try to import something in the step that exclusively lives in the docker image. As of August 2024, the Mozilla MLOps team has confirmed this behavior.
+   3. An important note: the above linked documentation says you can use docker images and the pypi and conda decorators together. According to the maintainers of the Outerbounds product that we use at Mozilla, this does not function as documented; instead, the pypi and conda decorators start from a fresh environment. So if you add one of the `@conda` or `@pypi` decorators _and also_ specify an `image` in the `kubernetes` decorator arguments, the flow will _run_, but it will _fail_ if you try to import something in the step that exclusively lives in the docker image. As of August 2024, the Mozilla MLOps team has confirmed this behavior.
 
 If you'd like to use a docker image, you can create your own custom image, push it to [Docker Hub](https://hub.docker.com/_/registry), and then pull it down by URL in your flow by decorating a step with:
 ```commandLine
 @kubernetes(image='url/of/your/image:tag')
 ```
-You can see an example Dockerfile here in this templates directory.
+You can see an example Dockerfile [here](`Dockerfile-metaflow`) in this templates directory.
 
 Please note that if your step should use our NVIDIA GPUs, it cannot use a docker image at present, as the Outerbounds `@nvidia` decorator does not interoperate with docker image specification. In this case, please use the `@pypi` and `@conda` decorators for dependencies as documented above.
 
@@ -155,7 +155,7 @@ As the Serve config file contents and the Dockerfile created in the previous ste
 
 1. Build the docker image locally using [docker build](https://docs.docker.com/reference/cli/docker/buildx/build/) command:
     ```sh
-    docker build -t template_rayserve_image:v1 -f Dockerfile-rayserve .
+    docker build -t template_rayserve_image:v1 -f Dockerfile-metaflow-rayserve .
     ```
 2. Run a container from the image using [docker run](https://docs.docker.com/reference/cli/docker/container/run/) command and start the Ray Serve app locally by running the [serve run](https://docs.ray.io/en/latest/serve/api/index.html#serve-run) command inside the container
 

--- a/src/mozmlops/templates/README.md
+++ b/src/mozmlops/templates/README.md
@@ -52,6 +52,22 @@ $METAFLOW_PROFILE=local python template_flow.py run --offline True
 
 Eventually you should see the flow finish with "Task finished successfully." Once you see that, you know you've got a working minimal flow: you're now ready to start putting your model training code _into_ this flow to run it remotely. Comments _inside_ the template file should help you understand where to put that code, and demonstrate some of the tools Metaflow makes available to you.
 
+ ## Using Docker with Model Orchestration Flows
+
+Flows in Metaflow permit you to include dependencies in each of your steps in two different ways:
+
+1. Adding the `@pypi` or `@conda` decorator and installing dependencies as each step runs ([documentation here](https://docs.metaflow.org/scaling/dependencies/libraries))
+2. Using a custom docker image with your dependencies in it, as described in [this documentation](https://docs.metaflow.org/scaling/dependencies/containers)
+   3. An important note: the above linked documentation says you can use docker images and the pypi and conda decorators together. According to the maintainers of the Outerbounds product that we use at Mozilla, this does not function as documented; instead, both the pypi and conda decorators start from a fresh environment. So if you specify _both_, the flow will _run_, but it will _fail_ if you try to import something in the step that exclusively lives in the docker image. As of August 2024, the Mozilla MLOps team has confirmed this behavior.
+
+If you'd like to use a docker image, you can create your own custom image, push it to [Docker Hub](https://hub.docker.com/_/registry), and then pull it down by URL in your flow by decorating a step with:
+```commandLine
+@kubernetes(image='url/of/your/image:tag')
+```
+You can see an example Dockerfile here in this templates directory.
+
+Please note that if your step should use our NVIDIA GPUs, it cannot use a docker image at present, as the Outerbounds `@nvidia` decorator does not interoperate with docker image specification. In this case, please use the `@pypi` and `@conda` decorators for dependencies as documented above.
+
  ## Next: Tracking, Visualizing, and Evaluating ML Experiments
 
 An admin from Mozilla’s MLOps team needs to set you up with your team on Weights and Biases.[Ask them to add you](https://mozilla-hub.atlassian.net/wiki/spaces/DATA/pages/471010754/Getting+a+Weights+and+Biases+account), and then once they do, you can click through to the invitation to create your Weights and Biases account.


### PR DESCRIPTION
### Ticket:

- [DENG-3849](https://mozilla-hub.atlassian.net/browse/DENG-3849)

### This change set documents how to use Docker with flows. There's:

- The docker template we had, now with inline documentation!
- Information in the README of how and when to use docker images in flows. 




