### PR TITLE
DENG-6159 Add Ray Serve example to demonstrate batching feature

### DIFF
--- a/examples/ray_serve/batched_translator/batched_translator.py
+++ b/examples/ray_serve/batched_translator/batched_translator.py
@@ -65,3 +65,6 @@ class BatchedTranslator:
 # Ray Serve Application builder
 def batched_translator_app_builder(args: BatchedTranslatorArgs) -> Application:
     return BatchedTranslator.bind(args.task, args.model)
+
+# Un-comment the following line ONLY to auto-generate Serve config file using `serve build` command and then comment it back again
+#batched_translator_app = BatchedTranslator.bind()

--- a/examples/ray_serve/batched_translator/batched_translator.py
+++ b/examples/ray_serve/batched_translator/batched_translator.py
@@ -1,0 +1,39 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# The original code in this file comes from the Ray serve documentation:
+# https://docs.ray.io/en/latest/serve/develop-and-deploy.html#convert-a-model-into-a-ray-serve-application
+
+from ray import serve
+
+from fastapi import FastAPI
+from pydantic import BaseModel, Field
+from transformers import pipeline
+
+app = FastAPI()
+
+
+class TranslateRequest(BaseModel):
+    text: str = Field(description="The text to translate")
+
+
+@serve.deployment()
+@serve.ingress(app)
+class BatchedTranslator:
+    def __init__(self):
+        # Load model
+        self.model = pipeline("translation_en_to_fr", model="t5-small")
+
+    @app.post("/")
+    def translate(self, translate_request: TranslateRequest) -> str:
+        # Run inference
+        model_output = self.model(translate_request.text)
+
+        # Post-process output to return only the translation text
+        translation = model_output[0]["translation_text"]
+
+        return translation
+
+
+batched_translator_app = BatchedTranslator.bind()

--- a/examples/ray_serve/batched_translator/requirements.batched_translator.txt
+++ b/examples/ray_serve/batched_translator/requirements.batched_translator.txt
@@ -1,0 +1,6 @@
+# Common dependencies to run any Ray Serve app
+ray[serve]==2.9.3
+
+# Dependencies specific to the batched translator Ray Serve app in `examples` folder
+transformers==4.45.2
+torch==2.4.1

--- a/examples/ray_serve/batched_translator/serve_config.yaml
+++ b/examples/ray_serve/batched_translator/serve_config.yaml
@@ -1,0 +1,32 @@
+# This file was generated using the `serve build` command on Ray v2.9.3.
+# It was further tweaked (see comments at tweaked sites below) to adapt it to the batched translator Ray Serve app.
+
+proxy_location: EveryNode
+
+http_options:
+  host: 0.0.0.0
+  port: 8000
+
+grpc_options:
+  port: 9000
+  grpc_servicer_functions: []
+
+logging_config:
+  encoding: TEXT
+  log_level: INFO
+  logs_dir: null
+  enable_access_log: true
+
+applications:
+- name: batched_en_fr_translator # changed auto generated value to assign a meaningful name for the app
+  route_prefix: /translate # changed auto generated value to assign the right route prefix for the app
+  import_path: batched_translator:batched_translator_app_builder # changed auto generated value to set the application builder for the app
+  args: # added this entire key to pass args to the Application
+    task: "translation_en_to_fr"
+    model: "t5-small"
+  runtime_env: {}
+  deployments:
+  - name: BatchedTranslator
+    user_config: # added this entire key to pass batch configuration to the BatchedTranslator Deployment
+      max_batch_size: 8
+      batch_wait_timeout_s: 1


### PR DESCRIPTION
### Goal(s) of this Pull Request:

- The Translation team has expressed interest for one of their projects (related to WebCompat) to use batching for (LLM based) inference server in order to optimized the hardware usage and reduce compute costs for the inference.

As a prepration for onboarding them, here is an example demonstrating Ray Serve's dynamic request batching feature.

### Example of how it works:

... Added README to explain how it works.

### Acceptance criteria:

In order to approve, reviewer must be able to...

- [x] ...
