### PR TITLE
Add run of template_flow to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,15 @@ jobs:
             export GOOGLE_APPLICATION_CREDENTIALS="/tmp/gcp.json"
             echo "$GCLOUD_SERVICE_KEY" > "$GOOGLE_APPLICATION_CREDENTIALS"
             poetry run pytest -m integration
+      - run:
+          name: "Running a flow"
+          # These commands load our application credentials from the service account
+          # So that we can run the integration tests.
+          # See https://cloud.google.com/docs/authentication/production
+          command: |
+            outerbounds configure $OB_DEFAULT_PERIMETER_CONFIG_KEY
+            cd src/mozmlops/templates
+            python template_flow.py --no-pylint run 
 
 
 # Orchestrate jobs using workflows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,9 +54,9 @@ jobs:
           # So that we can run the integration tests.
           # See https://cloud.google.com/docs/authentication/production
           command: |
-            outerbounds configure $OB_DEFAULT_PERIMETER_CONFIG_KEY
+            poetry run outerbounds configure $OB_DEFAULT_PERIMETER_CONFIG_KEY
             cd src/mozmlops/templates
-            python template_flow.py --no-pylint run 
+            poetry run python template_flow.py --no-pylint run 
 
 
 # Orchestrate jobs using workflows


### PR DESCRIPTION
The CI Run on this PR will determine whether this is indeed working now, but the commands did work locally before I pushed!

The goal of this PR, as per [DENG-6143](https://mozilla-hub.atlassian.net/browse/DENG-6143), is to add a step to CI confirming that our current understanding of the Metaflow API is working as we expect. It does so by running our template_flow, with the expectation of a successful result. 