### PR TITLE
Add a nightly test sequence to Circle Ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2.1
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/jobs-steps/#jobs-overview & https://circleci.com/docs/configuration-reference/#jobs
 jobs:
-  pre-merge-job:
+  all-tests-job:
     # Specify the execution environment. You can specify an image from Docker Hub or use one of our convenience images from CircleCI's Developer Hub.
     # See: https://circleci.com/docs/executor-intro/ & https://circleci.com/docs/configuration-reference/#executor-job
     docker:
@@ -62,10 +62,23 @@ jobs:
 # Orchestrate jobs using workflows
 # See: https://circleci.com/docs/workflows/ & https://circleci.com/docs/configuration-reference/#workflows
 workflows:
-  pre-merge-workflow: # This is the name of the workflow, feel free to change it to better match your workflow.
+  # This is the name of the workflow, feel free to change it to better match your workflow.
+  pre-merge-workflow:
     # Inside the workflow, you define the jobs you want to run.
     jobs:
-      - pre-merge-job:
+      - all-tests-job:
+          # Provides environment variables needed to integrate with GCS for integration tests
+         context: data-eng-circleci-tests
+  nightly-workflow:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - main
+    jobs:
+      - all-tests-job:
           # Provides environment variables needed to integrate with GCS for integration tests
          context: data-eng-circleci-tests
 


### PR DESCRIPTION
### Goal(s) of this Pull Request:

- Run our tests (specifically integration tests and smoke tests) nightly, to warn us if one of our dependencies no longer works for the sorts of ways we use it in the way we expect.

- When CircleCI fails we all get an email, so we should be notified via email if this nightly run fails.