### PR TITLE
Replace @nvidia decorator with @nvct decorator:

### DIFF
--- a/README.troubleshooting.orchestration.md
+++ b/README.troubleshooting.orchestration.md
@@ -40,7 +40,7 @@ Note that @pypi does not currently support source distributions
 **Solution:**
 
 This error happens when your Flow depends on a package that is only available as a [source distribution](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#source-distributions) which [`@pypi` decorator doesn't support](https://docs.metaflow.org/api/step-decorators/pypi). The way to resolve this is:
-- Create a custom docker image with all of your Flow's dependencies, push that up on a registry (see [README.Docker.md](./src/mozmlops/templates/README.Docker.md) for reference) and then pull it down via the `image` argument of `@kubernetes` decorator. The caveat is that custom docker images are not yet supported on NVIDIA cloud (i.e. `@nvidia` decorator).
+- Create a custom docker image with all of your Flow's dependencies, push that up on a registry (see [README.Docker.md](./src/mozmlops/templates/README.Docker.md) for reference) and then pull it down via the `image` argument of `@kubernetes` decorator. The caveat is that custom docker images are not yet supported on NVIDIA cloud (i.e. `@nvct` decorator).
 
 ### Issue 4: Out of Memory error (Task finished with exit code 137)
 **Error message (while running an OB flow):**

--- a/examples/image_classifier/image_classifier_flow.py
+++ b/examples/image_classifier/image_classifier_flow.py
@@ -12,7 +12,7 @@ from metaflow import (
     environment,
     kubernetes,
     pypi,
-    nvidia,
+    nvct,
 )
 from metaflow.cards import Markdown
 
@@ -59,12 +59,12 @@ class ImageClassifierFlow(FlowSpec):
         self.next(self.train)
 
     # Train the network
-    # Keep @nvidia decorator before @step decorator else the flow fails
+    # Keep @nvct decorator before @step decorator else the flow fails
     @pypi(
         python="3.11.9",
         packages={"torch": "2.4.1", "torchvision": "0.19.1", "mozmlops": "0.1.4"},
     )
-    @nvidia
+    @nvct
     # @kubernetes
     @card
     @environment(

--- a/src/mozmlops/templates/README.md
+++ b/src/mozmlops/templates/README.md
@@ -66,7 +66,7 @@ If you'd like to use a docker image, you can create your own custom image, push 
 ```
 You can see an example Dockerfile [here](Dockerfile-metaflow) in this templates directory.
 
-Please note that if your step should use our NVIDIA GPUs, it cannot use a docker image at present, as the Outerbounds `@nvidia` decorator does not interoperate with docker image specification. In this case, please use the `@pypi` and `@conda` decorators for dependencies as documented above.
+Please note that if your step should use our NVIDIA GPUs, it cannot use a docker image at present, as the Outerbounds `@nvct` decorator does not interoperate with docker image specification. In this case, please use the `@pypi` and `@conda` decorators for dependencies as documented above.
 
 > [!IMPORTANT]
 > Please refer to the [Troubleshooting](../../README.troubleshooting.orchestration.md) guide for the known issues and how to resolve them.


### PR DESCRIPTION
+ Assumes that the new decorator works just like @nvidia did.

### Goal(s) of this Pull Request:

- Update the examples to match the current Outerbounds API

### Example of how it works:

- Currently, it replaces @nvidia with @nvct

