### PR TITLE
Update template_flow.py to resolve pylint error

### DIFF
--- a/src/mozmlops/templates/template_flow.py
+++ b/src/mozmlops/templates/template_flow.py
@@ -108,7 +108,7 @@ class TemplateFlow(FlowSpec):
 
         # Load the Iris dataset
         iris = load_iris()
-        X, y = iris.data, iris.target
+        X, y = iris
 
         # Split the dataset into training and testing sets
         X_train, X_test, y_train, y_test = train_test_split(


### PR DESCRIPTION
change to prevent this error being thrown:

template_flow.py:111:16: E1101: Instance of 'tuple' has no 'data' member (no-member)
template_flow.py:111:27: E1101: Instance of 'tuple' has no 'target' member (no-member)

### Goal(s) of this Pull Request:

- resolve pylint error

### Example of how it works:

`iris` is a tuple, not an object

### Acceptance criteria:

In order to approve, reviewer must be able to...

- run the flow locally with no `pylint` errors
